### PR TITLE
Fix the version of google-auth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name='target-bigquery',
           'google-cloud-bigquery==1.26.0',
           'pytz==2018.4',
           'oauth2client',
+          "google-auth<2.0dev,>=1.19.1",
       ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
I would like to fix the version of google-auth, because the following error occurred when I ran target-bigquery.

```
Traceback(most recent call last):
 File "/opt/venv/target-bigquery/lib/python3.7/site-packages/pkg_resources/init.py", line 583, in _build_master
ws.require(requires)
 File "/opt/venv/target-bigquery/lib/python3.7/site-packages/pkg_resources/init.py", line 900, in require
needed = self.resolve(parse_requirements(requirements))
 File "/opt/venv/target-bigquery/lib/python3.7/site-packages/pkg_resources/init.py", line 791, in resolve
 raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (google - auth 2.3.3(/opt/venv / target - bigquery / lib / python3.7 / site - packages), Requirement.parse('google-auth<2.0dev,>=1.19.1'), { 'google-api-core'})
```